### PR TITLE
SWF-3869: Update PLF components versions to 5.0.x-SNAPSHOT

### DIFF
--- a/agital-template/pom.xml
+++ b/agital-template/pom.xml
@@ -37,12 +37,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.portal</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.resources</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/globex-template/pom.xml
+++ b/globex-template/pom.xml
@@ -37,12 +37,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.portal</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.resources</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <org.exoplatform.platform.version>4.5.x-SNAPSHOT</org.exoplatform.platform.version>
+    <org.exoplatform.platform.version>5.0.x-SNAPSHOT</org.exoplatform.platform.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/responsive-template/pom.xml
+++ b/responsive-template/pom.xml
@@ -32,12 +32,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.portal</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gatein.portal</groupId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.resources</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
* maven dependencies updated to depends on
    * PLF versions 5.0.x-SNAPSHOT
    * groupId org.exoplatform.gatein.* instead of org.gatein for
gatein-wci, gatein-pc and gatein-portal